### PR TITLE
v5.0.0: Исправление потери типов typescript'ом

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,17 @@
     "CHANGELOG.md",
     "logo.png"
   ],
+  "dependencies": {
+    "@babel/core": "^7.23.7",
+    "@rollup/plugin-babel": "^6.0.4",
+    "@rollup/plugin-commonjs": "^25.0.7",
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-typescript": "^11.1.6",
+    "rollup": "^4.9.5",
+    "rollup-plugin-peer-deps-external": "^2.2.4",
+    "ts-node": "^10.9.1",
+    "typescript": "^4.1.3"
+  },
   "devDependencies": {
     "@babel/core": "^7.23.7",
     "@rollup/plugin-babel": "^6.0.4",
@@ -54,6 +65,7 @@
     "@types/react": ">=17",
     "@typescript-eslint/eslint-plugin": "^4.13.0",
     "@typescript-eslint/parser": "^4.14.1",
+    "axios": "^1.6.5",
     "eslint": "^7.31.0",
     "eslint-config-prettier": "^7.2.0",
     "eslint-import-resolver-typescript": "^2.3.0",
@@ -75,8 +87,9 @@
     "typescript": "^4.1.3"
   },
   "peerDependencies": {
-    "react": ">=17",
-    "axios": "^0.24.0"
+    "axios": "^0.24.0",
+    "lodash": "^4.17.21",
+    "react": ">=17"
   },
   "repository": {
     "type": "git",

--- a/src/hooks/orientationContext.tsx
+++ b/src/hooks/orientationContext.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { useOrientationChange } from './index';
+import useOrientationChange from './useOrientationChange';
 
 const OrientationContext = React.createContext({
   isLandscape: false,

--- a/src/types/localStorage.ts
+++ b/src/types/localStorage.ts
@@ -2,4 +2,5 @@ export interface LocalStorage {
   setItem: (key: string, value: unknown) => void;
   getItem: (key: string) => unknown;
   removeItem: (key: string) => void;
+  [x: string]: unknown;
 }

--- a/src/typings/typings.d.ts
+++ b/src/typings/typings.d.ts
@@ -1,4 +1,4 @@
-import { WindowType } from '../src';
+import { WindowType } from 'types/window';
 
 declare global {
   // eslint-disable-next-line

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,6 @@
     }
   },
   "main": "./src/index.ts",
-  "types": "./types/typings.d.ts",
   "include": ["src", "types"],
   "exclude": ["node_modules", "packages/*/node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,9 +14,10 @@
       "__tests__/*": ["__tests__/*"],
       "types/*": ["types/*"],
       "hooks/*": ["hooks/*"]
-    }
+    },
+    "types": ["axios", "react", "lodash", "node"]
   },
   "main": "./src/index.ts",
-  "include": ["src", "types"],
-  "exclude": ["node_modules", "packages/*/node_modules"]
+  "include": ["src"],
+  "exclude": ["node_modules"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1590,12 +1590,14 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-axios@^0.24.0:
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
-  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
+axios@^1.6.5:
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.5.tgz#2c090da14aeeab3770ad30c3a1461bc970fb0cd8"
+  integrity sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==
   dependencies:
-    follow-redirects "^1.14.4"
+    follow-redirects "^1.15.4"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 babel-jest@^29.5.0:
   version "29.5.0"
@@ -2550,10 +2552,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.1.tgz#bbef080d95fca6709362c73044a1634f7c6e7d05"
   integrity sha512-OMQjaErSFHmHqZe+PSidH5n8j3O0F2DdnVh8JB4j4eUQ2k6KvB0qGfrKIhapvez5JerBbmWkaLYUYWISaESoXg==
 
-follow-redirects@^1.14.4:
-  version "1.15.2"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
-  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+follow-redirects@^1.15.4:
+  version "1.15.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
+  integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==
 
 for-each@^0.3.3:
   version "0.3.3"
@@ -4314,6 +4316,11 @@ prop-types@^15.7.2:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.9.0"


### PR DESCRIPTION
Не получилось поправить без изменения структуры папок, поэтому сделал так: переместил папку types в src и переименовал в typings, чтобы не совпадало с уже имеющейся папкой types.

Поле `types` в tsconfig удалил, потому что в целом не уверен, что оно там должно быть (вижу поле [types только в compilerOptions](https://www.typescriptlang.org/tsconfig?#types), но не вне него). Да и удаление ни на что не повлияло.

После исправления потери типов, ts стал ругаться на `__localStorage__` (скриншот ниже), поэтому дополнил типизацию `__localStorage__`.

![image](https://github.com/ktsstudio/mediaproject-utils/assets/71431554/1326928e-2cf8-44b4-9fb8-8afd87267fff)
